### PR TITLE
add support for kubeconfigname at store level

### DIFF
--- a/cmd/switcher/switcher.go
+++ b/cmd/switcher/switcher.go
@@ -404,6 +404,10 @@ func initialize() ([]store.KubeconfigStore, *types.Config, error) {
 	for _, kubeconfigStoreFromConfig := range config.KubeconfigStores {
 		var s store.KubeconfigStore
 
+		if kubeconfigStoreFromConfig.KubeconfigName != nil && *kubeconfigStoreFromConfig.KubeconfigName != "" {
+			kubeconfigName = *kubeconfigStoreFromConfig.KubeconfigName
+		}
+
 		switch kubeconfigStoreFromConfig.Kind {
 		case types.StoreKindFilesystem:
 			filesystemStore, err := store.NewFilesystemStore(kubeconfigName, kubeconfigStoreFromConfig)


### PR DESCRIPTION
This is a documented feature https://github.com/danielfoehrKn/kubeswitch/blob/master/docs/kubeconfig_stores.md#specify-the-kubeconfig-name-pattern-to-search-for but there was no code for it, so there it is :)