### PR TITLE
fix invalid apiVersion

### DIFF
--- a/pkg/store/kubeconfig_store_eks.go
+++ b/pkg/store/kubeconfig_store_eks.go
@@ -259,7 +259,7 @@ func (s *EKSStore) GetKubeconfigForPath(path string) ([]byte, error) {
 				Name: contextName,
 				User: types.User{
 					ExecProvider: &types.ExecProvider{
-						APIVersion: "client.authentication.k8s.io/v1alpha1",
+						APIVersion: "client.authentication.k8s.io/v1beta1",
 						Command:    "aws",
 						Args: []string{
 							"--region",


### PR DESCRIPTION
Right now eks store fails with `error: exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"`

More info here: https://github.com/aws/aws-cli/issues/6920