### PR TITLE
Clarify bashrc installation and configuration if user does not have a `~/.kube/config` file

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,17 +1,20 @@
 # Installation
-## Option 1a - Homebrew
+
+## `switch` command
+
+### Option 1a - Homebrew
 
 Mac and Linux users can install both the `switch.sh` script and the `switcher` binary with `homebrew`.
 ```
 $ brew install danielfoehrkn/switch/switch
 ```
 
-Source the `switch.sh` script from the `homebrew` installation path.
+Source the `switch.sh` script from the `homebrew` installation path by adding this to `.bashrc`/`.zsh`:
 ```
-$ INSTALLATION_PATH=$(brew --prefix switch) && source $INSTALLATION_PATH/switch.sh
+INSTALLATION_PATH=$(brew --prefix switch) && source $INSTALLATION_PATH/switch.sh
 ```
 
-## Option 1b - MacPorts
+### Option 1b - MacPorts
 
 Mac users can also install both `switch.sh` and `switcher` from [MacPorts](https://www.macports.org)
 ```
@@ -24,9 +27,9 @@ Source the `switch.sh` script from the MacPorts root (/opt/local).
 $ source /opt/local/libexec/kubeswitch/switch.sh
 ```
 
-## Option 2 - Manual Installation
+### Option 2 - Manual Installation
 
-### From Source
+#### From source
 
 ```
 $ go get github.com/danielfoehrkn/kubeswitch
@@ -37,31 +40,43 @@ This builds the binaries to `/hack/switch/`.
 Copy the build binary for your OS / Architecture to e.g. `/usr/local/bin`
 and source the switch script from `/hack/switch/switch.sh`.
 
-### Github Releases
+#### From Github releases
 
 Download the switch script and the switcher binary.
-```
+
+```sh
 OS=linux                        # Pick the right os: linux, darwin (intel only)
 VERSION=0.7.0                   # Pick the current version.
 
 curl -L -o /usr/local/bin/switcher https://github.com/danielfoehrKn/kubeswitch/releases/download/${VERSION}/switcher_${OS}_amd64
-chmod +x /usr/local/bin/switcher 
+chmod +x /usr/local/bin/switcher
 
 curl -L -o  /usr/local/bin/switch.sh https://github.com/danielfoehrKn/kubeswitch/releases/download/${VERSION}/switch.sh
 chmod +x /usr/local/bin/switch.sh
 ```
 
 Source `switch.sh` in `.bashrc`/`.zsh` via:
-```
-$ source /usr/local/bin/switch.sh
+
+```sh
+source /usr/local/bin/switch.sh
 ```
 
-# Command completion
+## Set up finding kubeconfig files and contexts
+
+If you installed kubeswitch correctly, you can run the command `switch`
+and should see the contexts it can find with its default configuration.
+The command is only available once you open a new terminal, in case you load
+`switch.sh` through `.bashrc`/`.zsh`. If you get the error
+`Error: you need to point kubeswitch to a kubeconfig file` or do not see all
+desired kubeconfig contexts that you want to choose from, follow
+[kubeconfig stores](kubeconfig_stores.md) for the configuration.
+
+## Command completion
 
 Please [see here](command_completion.md) how to install command completion for bash and zsh shells.
 This completes both the `kubeswitch` commands as well as the context names.
 
-# Cleanup temporary kubeconfig files
+## Clean up temporary kubeconfig files
 
 To not alter the current shell session, `kubeswitch` does not spawn a new sub-shell.
 You need to configure a cleanup handler if you care to remove temporary kubeconfig files from `$HOME/.kube/.switch_tmp` when the shell session

--- a/docs/kubeconfig_stores.md
+++ b/docs/kubeconfig_stores.md
@@ -5,7 +5,7 @@ If you neither provide a flag or a `SwitchConfig` file, it will default to the f
 
 The `SwitchConfig` file is expected to be in the default location
 on the local filesystem at `~/.kube/switch-config.yaml` or set via flag `--config-path`.
-Example config files can be found [here](../resources/demo-config-files) but also in 
+Example config files can be found [here](../resources/demo-config-files) but also in
 the documentation for each store (see below).
 
 Please check the documentation for each kubeconfig store on how to use it
@@ -16,6 +16,10 @@ Please check the documentation for each kubeconfig store on how to use it
 
 Please note that, to search over **multiple** directories and kubeconfig stores,
 you need to use the `SwitchConfig` file.
+
+Also, if you do not have a default `~/.kube/config` file, kubeswitch will fail
+with `Error: you need to point kubeswitch to a kubeconfig file`, so you need
+to specify in the `SwitchConfig` file where to look.
 
 ## General Store configuration
 
@@ -39,6 +43,19 @@ kubeconfigStores:
   kubeconfigName: "*.myconfig"
   paths:
   - ~/.kube/my-other-kubeconfigs/
+```
+
+If you have several existing kubeconfig files in the directory `~/.kube`, the
+following simple configuration may work for you:
+
+```yaml
+kind: SwitchConfig
+version: v1alpha1
+kubeconfigStores:
+ - kind: filesystem
+   kubeconfigName: "config*"
+   paths:
+     - ~/.kube
 ```
 
 ### Disable kubeconfig previews
@@ -121,7 +138,7 @@ This is useful when
 - some search paths of a kubeconfig store (e.g., filesystem) should have a different index refresh interval
 - there are multiple Vault instances or Gardener landscapes to read from.
 
-A unique id is required to create a different index file per store, so that 
+A unique id is required to create a different index file per store, so that
 the index of each store can be refreshed individually.
 
 In the example below, two filesystem stores are configured.
@@ -164,4 +181,3 @@ that have to be filtered out and thus slowing down the search.
 
 To do this, create a `kubeswitch` alias via `--Kubeconfig-path` pointing
 to this directory or setup the kubeconfig path in the `SwitchConfig`.
-


### PR DESCRIPTION
Just a few things that I found with my initial setup of the tool. I don't have a `~/.kube/config` file since its default context could dangerously point to a production cluster. Therefore, an example for a simplistic kubeswitch config file was added and the error case is now explained in the installation guide. Also some Markdown lint fixes (only one h1 heading, no trailing whitespace, etc.).