### PR TITLE
fix: rancher address config var and docs mismatch

### DIFF
--- a/docs/stores/rancher/rancher.md
+++ b/docs/stores/rancher/rancher.md
@@ -1,11 +1,11 @@
 # Rancher store
 
-To use Rancher as a Kubeconfig store, please create an API token from the rancher UI first.
-Searching over multiple Rancher instances is supported but in this case `showPrefix` must be set to true to prevent conflicts.
+To use the Rancher store an API token is required. The token can be created in the Rancher UI.
+Searching over multiple Rancher instances is supported, but may require `showPrefix` to be set to `true` in the `SwitchConfig` file to avoid name collisions.
 
-# Configure Rancher in the SwitchConfig file
+## Configuration
 
-Below there is an example configuration for Rancher in the `SwitchConfig` file.
+The Rancher store configuration is defined in the `kubeswitch` configuration file. An example configuration is shown below:
 
 ```yaml
 kind: SwitchConfig
@@ -22,4 +22,5 @@ kubeconfigStores:
       path: ~/.kube/cache
 ```
 
-The rancher store can work without filesystem cache but rancher api will create by default a new kubeconfig file everytime the context is selected without invalidating the old one. Therefore it is recommended to activate the filesystem [cache](../../kubeconfig_cache.md). 
+The Rancher store can be used without a filesystem cache but the Rancher API will create a new Kubeconfig file (and token) every time you switch to one of the Rancher contexts.
+Therefore, it is recommended to use a filesystem cache.

--- a/docs/stores/rancher/rancher.md
+++ b/docs/stores/rancher/rancher.md
@@ -14,7 +14,7 @@ kubeconfigStores:
 - kind: rancher
   id: rancher
   config:
-    rancherAddress: https://rancher.yourdomain.com/v3
+    rancherAPIAddress: https://rancher.yourdomain.com/v3
     rancherToken: token-12abc:bmjlzslas......x4hv5ptc29wt4sfk
   cache:
     kind: filesystem

--- a/pkg/store/kubeconfig_store_rancher.go
+++ b/pkg/store/kubeconfig_store_rancher.go
@@ -39,8 +39,8 @@ func NewRancherStore(store types.KubeconfigStore) (*RancherStore, error) {
 		}
 	}
 
-	rancherAddress := rancherStoreConfig.RancherAddress
-	if len(rancherAddress) == 0 {
+	rancherAPIAddress := rancherStoreConfig.RancherAPIAddress
+	if len(rancherAPIAddress) == 0 {
 		return nil, fmt.Errorf("when using the Rancher kubeconfig store, the address of Rancher has to be provided via SwitchConfig file")
 	}
 
@@ -53,7 +53,7 @@ func NewRancherStore(store types.KubeconfigStore) (*RancherStore, error) {
 		Logger:          logrus.New().WithField("store", types.StoreKindRancher),
 		KubeconfigStore: store,
 		ClientOpts: &clientbase.ClientOpts{
-			URL:      rancherAddress,
+			URL:      rancherAPIAddress,
 			TokenKey: rancherToken,
 		},
 	}, nil

--- a/types/config.go
+++ b/types/config.go
@@ -219,8 +219,8 @@ type GKEAuthentication struct {
 }
 
 type StoreConfigRancher struct {
-	// RancherAddress is the URL of the Rancher API, e.g. https://rancher.example.com/v3
-	RancherAddress string `yaml:"rancherAPIAddress"`
+	// RancherAPIAddress is the URL of the Rancher API, e.g. https://rancher.example.com/v3
+	RancherAPIAddress string `yaml:"rancherAPIAddress"`
 	// RancherToken is the token used to authenticate against the Rancher API, format: token-12abc:bmjlzslas......x4hv5ptc29wt4sfk
 	RancherToken string `yaml:"rancherToken"`
 }


### PR DESCRIPTION
While setting up the Rancher store I've noticed that the sample in the docs uses the `rancherAddress`  map key, while the code expects the key to be `rancherAPIAddress`. I've fixed the docs as well as renamed the variable in the go code to use the same name just to make it more clear. Also updated the wording on the Rancher store docs a bit.

Tests still passing and there are no functional changes.