### PR TITLE
fix: version flag in switch.sh

### DIFF
--- a/hack/switch/switch.sh
+++ b/hack/switch/switch.sh
@@ -312,6 +312,10 @@ function switch(){
                      VERSION=$1
                      shift
                      ;;
+                  --version)
+                     VERSION=$1
+                     shift
+                     ;;
                   *)
                      SET_CONTEXT=$1
                      shift
@@ -352,7 +356,7 @@ function switch(){
 
   if [ -n "$VERSION" ]
   then
-    $EXECUTABLE_PATH version
+    $EXECUTABLE_PATH "$VERSION"
     return
   fi
 


### PR DESCRIPTION
This fixes `--version` flag and fixes behaviour of the flags vs. `version` command.

Before / after:

```diff
 $ switch -v
-Switch:
-		version     : v0.7.2
-		build date  : 2022-09-20
-		go version  : go1.19
-		go compiler : gc
-		platform    : linux/amd64
+switch version v0.7.2
 
 $ switch --version
-W0206 01:24:46.618960  341653 loader.go:222] Config not found: switch version v0.7.2
-error: current-context is not set
-switched to context "".
+switch version v0.7.2
```

Output of `switch version` stays the same.
