### PR TITLE
change(switch): dont use alias for rm command

### DIFF
--- a/hack/switch/switch.fish
+++ b/hack/switch/switch.fish
@@ -59,7 +59,7 @@ function kubeswitch
 
     set -l switchTmpDirectory "$HOME/.kube/.switch_tmp/config"
     if test -n "$KUBECONFIG"; and string match -q "*$switchTmpDirectory*" -- "$KUBECONFIG"
-      rm -f "$KUBECONFIG"
+      \rm -f "$KUBECONFIG"
     end
 
     set -gx KUBECONFIG "$KUBECONFIG_PATH"

--- a/hack/switch/switch.sh
+++ b/hack/switch/switch.sh
@@ -68,7 +68,7 @@ function switch(){
   local switchTmpDirectory="$HOME/.kube/.switch_tmp/config"
   if [[ -n "$KUBECONFIG" && "$KUBECONFIG" == *"$switchTmpDirectory"* ]]
   then
-    rm -f "$KUBECONFIG"
+    \rm -f "$KUBECONFIG"
   fi
 
   export KUBECONFIG="$KUBECONFIG_PATH"


### PR DESCRIPTION
As I use an alias for rm commands, (alises to rip), an error appear every time I try to change my context

```
➜  switch git:(master) switch tools
error: Found argument '-f' which wasn't expected, or isn't valid in this context
```

I've made this commit to force raw command