### PR TITLE
docs(EKS Store): Fix Markdown

### DIFF
--- a/docs/stores/eks/eks.md
+++ b/docs/stores/eks/eks.md
@@ -3,7 +3,7 @@
 Kubeswitch can discover EKS clusters from AWS.
 
 At the moment, Kubeswitch works only with [named profiles](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html), make sure it is working before setting up the store.
-A good test is to follow the "(Create kubeconfig automatically)[https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html#create-kubeconfig-automatically]" documentation as Kubeswitch will output the same configuration (with some exceptions pending implementation).
+A good test is to follow the "[Create kubeconfig automatically](https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html#create-kubeconfig-automatically)" documentation as Kubeswitch will output the same configuration (with some exceptions pending implementation).
 
 ## Setup
 
@@ -13,7 +13,8 @@ This is because the generated kubeconfigs use the AWS CLI as a credential helper
 Next, create the EKS store configuration in the `kubeswitch` configuration file.
 
 Search over all EKS clusters for a config profile and region:
-```
+
+```yaml
 cat ~/.kube/switch-config.yaml
 
 kind: SwitchConfig
@@ -40,21 +41,25 @@ Using multiple profiles and/or regions is possible by defining multiple store co
 
 ## Search for EKS Clusters
 
-Kubeconfig context names are fuzzy-searchable using the following semantics. 
+Kubeconfig context names are fuzzy-searchable using the following semantics.
 The `eks_` prefix helps to narrow down the search to only EKS clusters.
 
 In General:
+
 - `eks_<profile>--<region>--<cluster-name>/<cluster-name>`
 
 Example:
+
 - `eks_prod1--eu-west-1--kubeswitch_test/kubeswitch_test`
 
 In this example:
+
 - Configuration Profile: prod1
 - Region: eu-west-1
 - EKS Cluster name: kubeswitch_test
 
-However, remember that you can always define an `alias` for each context to define a name that you can better remember or query .
+However, remember that you can always define an `alias` for each context to define a name that you can better remember or query.
 
 This is how looks like using the `switch` search:
+
 - In addition to the sanitized kubeconfig preview, additional EKS cluster information is shown such as the `Kubernetes version`


### PR DESCRIPTION
Intended to fix the Markdown link to create Kube config and fixed the
other markdownlint warnings (except line length).

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
