### PR TITLE
fix(fish): fix 'rm' command unalias

### DIFF
--- a/cmd/switcher/init.go
+++ b/cmd/switcher/init.go
@@ -154,7 +154,7 @@ function kubeswitch
 
 	set -l switchTmpDirectory "$HOME/.kube/.switch_tmp/config"
 	if test -n "$KUBECONFIG"; and string match -q "*$switchTmpDirectory*" -- "$KUBECONFIG"
-	  \rm -f "$KUBECONFIG"
+	  command rm -f "$KUBECONFIG"
 	end
 
 	set -gx KUBECONFIG "$KUBECONFIG_PATH"


### PR DESCRIPTION
Using backslash in fish to prevent alias expansion does not work (`fish: Unknown command: \rm`).  
Instead you need to use `command`: https://github.com/fish-shell/fish-shell/issues/5076#issuecomment-401511602