### PR TITLE
fix: calling `rm` command in hack/switch/switch.fish

### DIFF
--- a/hack/switch/switch.fish
+++ b/hack/switch/switch.fish
@@ -59,7 +59,7 @@ function kubeswitch
 
     set -l switchTmpDirectory "$HOME/.kube/.switch_tmp/config"
     if test -n "$KUBECONFIG"; and string match -q "*$switchTmpDirectory*" -- "$KUBECONFIG"
-      \rm -f "$KUBECONFIG"
+      command rm -f "$KUBECONFIG"
     end
 
     set -gx KUBECONFIG "$KUBECONFIG_PATH"


### PR DESCRIPTION
Fixes #124 

The main bug was fixed already in #121.
This PR fixes the code in `hack/switch/switch.fish`, where the problem still exists.