### PR TITLE
Fail if Vault data is empty

### DIFF
--- a/pkg/store/kubeconfig_store_vault.go
+++ b/pkg/store/kubeconfig_store_vault.go
@@ -299,6 +299,10 @@ func (s *VaultStore) GetKubeconfigForPath(path string, _ map[string]string) ([]b
 				if err != nil {
 					return nil, fmt.Errorf("cannot read kubeconfig from %q: %v", secretsPath, err)
 				}
+				if len(bytes) == 0 {
+					s.Logger.Debugf("vault: data is empty from %q", secretsPath)
+					return nil, fmt.Errorf("kubeconfig is empty from %q", secretsPath)
+				}
 				return bytes, nil
 			}
 		}


### PR DESCRIPTION
I found that I have a Vault path that has no data (which is something I should get cleaned up). When configured with a filesystem cache, this result from Vault with empty data results in the following error when running `switch list-contexts`:

```
panic: runtime error: index out of range [0] with length 0

goroutine 24 [running]:
github.com/danielfoehrkn/kubeswitch/pkg/util/kubectx_copied.New({0x366a480, 0x0, 0x0}, {0xc000750cc0, 0x57}, 0x0)
	kubeswitch/pkg/util/kubectx_copied/kubeconfig.go:73 +0x11c
github.com/danielfoehrkn/kubeswitch/pkg/cache/file.(*fileCache).GetKubeconfigForPath(0xc0006d0900, {0xc0003bc060, 0x1d}, 0x0)
	kubeswitch/pkg/cache/file/fileCache.go:137 +0x2bc
github.com/danielfoehrkn/kubeswitch/pkg.DoSearch.func4({0x249fcd8, 0xc0006d0900}, 0xc000058480, {0xc00047a4d0, {0xc0004fe180, 0x3d}, {0xc000154000, 0x43}, {0x2142bd3, 0x5}, ...})
	kubeswitch/pkg/search.go:162 +0x312
created by github.com/danielfoehrkn/kubeswitch/pkg.DoSearch in goroutine 1
	kubeswitch/pkg/search.go:140 +0x8f8
```

To get around this we can check for an empty result and return nil for the kubeconfig.