### PR TITLE
fix 🐛(kubeconfig filesystem store): kubeswitch follows symlinks

### DIFF
--- a/pkg/store/kubeconfig_store_file.go
+++ b/pkg/store/kubeconfig_store_file.go
@@ -106,7 +106,8 @@ func (s *FilesystemStore) searchDirectory(
 			}
 			return nil
 		},
-		Unsorted: false, // (optional) set true for faster yet non-deterministic enumeration
+		Unsorted:            false, // (optional) set true for faster yet non-deterministic enumeration
+		FollowSymbolicLinks: true,
 	}); err != nil {
 		channel <- SearchResult{
 			KubeconfigPath: "",


### PR DESCRIPTION
Just a little flag /on to follow symlinks in path set in the switch-config.

I don't think there is an issue to having it /on.