### PR TITLE
Add flag to opt out of existence check when switching namespaces

### DIFF
--- a/cmd/switcher/namespace.go
+++ b/cmd/switcher/namespace.go
@@ -19,7 +19,8 @@ import (
 )
 
 var (
-	namespaceCommand = &cobra.Command{
+	checkExistence   bool = true
+	namespaceCommand      = &cobra.Command{
 		Use:     "namespace",
 		Aliases: []string{"ns"},
 		Short:   "Change the current namespace",
@@ -33,7 +34,7 @@ var (
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 1 && len(args[0]) > 0 {
-				return ns.SwitchToNamespace(args[0], getKubeconfigPathFromFlag())
+				return ns.SwitchToNamespace(args[0], getKubeconfigPathFromFlag(), checkExistence)
 			}
 
 			return ns.SwitchNamespace(getKubeconfigPathFromFlag(), stateDirectory, noIndex)
@@ -49,7 +50,7 @@ var (
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return ns.SwitchToNamespace("default", getKubeconfigPathFromFlag())
+			return ns.SwitchToNamespace("default", getKubeconfigPathFromFlag(), false)
 		},
 		SilenceErrors: true,
 	}
@@ -57,6 +58,7 @@ var (
 
 func init() {
 	setCommonFlags(namespaceCommand)
+	namespaceCommand.Flags().BoolVar(&checkExistence, "check-existence", true, "Check if the namespace exists before switching to it (default true)")
 	rootCommand.AddCommand(namespaceCommand)
 	rootCommand.AddCommand(unsetNamespaceCommand)
 }


### PR DESCRIPTION
We have a tool that chooses a cluster and namespace based on runtime data, and
by the time we have decided what cluster and namespace to connect to, we already
know that the namespace exists in the cluster.

We want to extend this tool to support multiple switching mechanisms (rather than
just `kubectl config use-context` and `kubectl config set-context`), and but the
existence check for the namespace is prohibitively slow on some of our clusters.
To avoid paying that penalty, this change adds a flag to `switch ns` which allows
the user to opt out of the existence check.

```
λ switch ns does-not-exist
namespace "does-not-exist" not foundexit status 1

λ switch ns does-not-exist --check-existence=false
```
