### PR TITLE
fix(namespaces): increase QPS and burst rate limits

### DIFF
--- a/pkg/subcommands/ns/ns.go
+++ b/pkg/subcommands/ns/ns.go
@@ -315,6 +315,10 @@ func getClient(kubeconfigPath string) (client.Client, error) {
 		return nil, fmt.Errorf("unable to create rest config: %v", err)
 	}
 
+	// increase QPS and Burst to avoid rate limiting, these values are the same as kubectl uses
+	restConfig.QPS = 50.0
+	restConfig.Burst = 300
+
 	client, err := client.New(restConfig, client.Options{
 		Scheme: scheme,
 	})


### PR DESCRIPTION
This PR increases the rate limits (QPS and burst) of the namespace switching component. This fixes the issue of the namespace switcher timing out while fetching the namespaces from a cluster due to cache discovery of the kubernetes API / client-go taking too long on clusters with lots of CRDs. This is a known issue, cf. [this blog post from 2022](https://jonnylangefeld.com/blog/the-kubernetes-discovery-cache-blessing-and-curse) and other users have also reported issues for similar timeouts in #127.

I've updated QPS to `50.0` and burst to `300` from the defaults specified in https://github.com/danielfoehrKn/kubeswitch/blob/a6981cf4bded76d22ffc2ec8919b1e0d528c1f23/vendor/k8s.io/client-go/rest/config.go#L43-L46

The default burst for cache discovery is set in https://github.com/danielfoehrKn/kubeswitch/blob/a6981cf4bded76d22ffc2ec8919b1e0d528c1f23/vendor/k8s.io/client-go/discovery/discovery_client.go#L688 to `300`, but I'm not sure if it really is being properly propagated here.

Anyway, the new values `50`/ `300` are based on the defaults in the kubectl code found in https://github.com/kubernetes/kubernetes/blob/5f594f42159f2ee84f805d382638f77dd5967177/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go#L95-L97

Setting this substantially increased the responsiveness and I haven't since seen this issue on clusters with ~350 CRDs where the namespacer switcher previously was not able to grab namespaces at all.