### PR TITLE
add support for searching for CAPI clusters in the current context

### DIFF
--- a/docs/stores/capi/capi.md
+++ b/docs/stores/capi/capi.md
@@ -12,5 +12,7 @@ version: v1alpha1
 kubeconfigStores:
 - kind: capi
   config:
-    kubeconfigPath: "/home/user/.kube/management.config"
+    # Optionally specify a kubeconfigPath for a management cluster, 
+    # if not specified your current kube context will be searched for any CAPI clusters
+    kubeconfigPath: "/home/user/.kube/management.config" 
 ```

--- a/pkg/store/kubeconfig_store_capi.go
+++ b/pkg/store/kubeconfig_store_capi.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/clientcmd"
@@ -139,7 +140,7 @@ func (s *CapiStore) StartSearch(channel chan storetypes.SearchResult) {
 	if err != nil {
 		// if kubeconfigPath for mgmt cluster is defined error out and return if the Cluster CRD is not installed
 		// otherwise silently fail as our current context might not have CAPI installed
-		if s.Config.KubeconfigPath != "" {
+		if s.Config.KubeconfigPath != "" || !meta.IsNoMatchError(err) {
 			channel <- storetypes.SearchResult{
 				KubeconfigPath: "",
 				Error:          fmt.Errorf("unable to list clusters: %w", err),

--- a/types/config.go
+++ b/types/config.go
@@ -263,7 +263,7 @@ type StoreConfigAkamai struct {
 
 type StoreConfigCapi struct {
 	// KubeconfigPath is the path on the local filesystem pointing to the kubeconfig
-	// for the management cluster
+	// for the management cluster. If none is specified the current context will be used to look up clusters
 	KubeconfigPath string `yaml:"kubeconfigPath"`
 }
 


### PR DESCRIPTION
This PR allows you to passively search any cluster in your current context for CAPI clusters if a kubeconfigPath is not defined. This makes this store more flexible as mgmt clusters are deleted, created, and switched between. Open to any feedback on any explanations or implementations here. an alternative to this is we could add an explicit `useCurrentContext: true` bool or something like that