### PR TITLE
fix: Removes GKE CA Data when using DNS Endpoint

### DIFF
--- a/pkg/store/kubeconfig_store_gke.go
+++ b/pkg/store/kubeconfig_store_gke.go
@@ -306,12 +306,18 @@ func (s *GKEStore) GetKubeconfigForPath(path string, _ map[string]string) ([]byt
 	}
 
 	var endpoint string
+	var certificate string
+
+	certificate = cluster.MasterAuth.ClusterCaCertificate
+
 	if s.Config.PreferredEndpoint == nil {
 		endpoint = cluster.Endpoint
 	} else {
 		switch *s.Config.PreferredEndpoint {
 		case types.GkeDnsEndpoint:
 			endpoint = cluster.ControlPlaneEndpointsConfig.DnsEndpointConfig.Endpoint
+			// DNS Endpoint certificate is not signed this Certificate Authority
+			certificate = ""
 		case types.GkePrivateEndpoint:
 			endpoint = cluster.ControlPlaneEndpointsConfig.IpEndpointsConfig.PrivateEndpoint
 		case types.GkePublicEndpoint:
@@ -329,7 +335,7 @@ func (s *GKEStore) GetKubeconfigForPath(path string, _ map[string]string) ([]byt
 		Clusters: []types.KubeCluster{{
 			Name: contextName,
 			Cluster: types.Cluster{
-				CertificateAuthorityData: cluster.MasterAuth.ClusterCaCertificate,
+				CertificateAuthorityData: certificate,
 				Server:                   fmt.Sprintf("https://%s", endpoint),
 			},
 		}},


### PR DESCRIPTION
When using the GKE DNS Endpoint, GCP uses a different CA, Google Trust Service, LLC, to sign the certificate.  Since this CA is publicly trusted, there is no need to set CA here.

The GKE API Authentication documentation only mention getting CA data when using IP-based endpoints:
https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication#environments-without-gcloud