### PR TITLE
fix: manage id in akamai store

### DIFF
--- a/pkg/store/kubeconfig_store_akamai.go
+++ b/pkg/store/kubeconfig_store_akamai.go
@@ -83,7 +83,13 @@ func (s *AkamaiStore) InitializeAkamaiStore() error {
 
 // GetID returns the unique store ID
 func (s *AkamaiStore) GetID() string {
-	return fmt.Sprintf("%s.default", s.GetKind())
+	id := "default"
+
+	if s.KubeconfigStore.ID != nil {
+		id = *s.KubeconfigStore.ID
+	}
+
+	return fmt.Sprintf("%s.%s", s.GetKind(), id)
 }
 
 func (s *AkamaiStore) GetKind() types.StoreKind {


### PR DESCRIPTION
This pull request includes an important change to the `GetID` method in the `AkamaiStore` struct in the `pkg/store/kubeconfig_store_akamai.go` file. The change ensures that the store ID is dynamically determined based on the presence of an ID in the `KubeconfigStore`.

Key change:

* [`pkg/store/kubeconfig_store_akamai.go`](diffhunk://#diff-c32bb69d6c62ce3ddd5494633e9d77b86aa27b15ed385d1c2211b3608c5bd144L86-R92): Modified the `GetID` method to check if `KubeconfigStore.ID` is not nil and use its value; otherwise, it defaults to "default". This ensures a more flexible and accurate ID generation.