### PR TITLE
fix(plugin): manage multiple local ID

### DIFF
--- a/pkg/store/kubeconfig_store_plugins.go
+++ b/pkg/store/kubeconfig_store_plugins.go
@@ -87,7 +87,11 @@ func (s *PluginStore) GetID() string {
 
 	id, err := s.Client.GetID(ctx)
 	if err != nil {
-		return fmt.Sprintf("%s.default", s.GetKind())
+		localID := "default"
+		if s.KubeconfigStore.ID != nil {
+			localID = *s.KubeconfigStore.ID
+		}
+		return fmt.Sprintf("%s.%s", s.GetKind(), localID)
 	}
 	return id
 }


### PR DESCRIPTION
This pull request includes a change to the `GetID` method in the `pkg/store/kubeconfig_store_plugins.go` file to improve the handling of the `ID` field.

* Modified the `GetID` method to use a local `ID` from `KubeconfigStore` if available, defaulting to "default" otherwise.