### PR TITLE
feat: add "show" command

### DIFF
--- a/cmd/switcher/show.go
+++ b/cmd/switcher/show.go
@@ -1,0 +1,48 @@
+// Copyright 2025 The Kubeswitch authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package switcher
+
+import (
+	"fmt"
+
+	"github.com/danielfoehrkn/kubeswitch/pkg/subcommands/show"
+	"github.com/spf13/cobra"
+)
+
+var (
+	showCmd = &cobra.Command{
+		Use:   "show",
+		Short: "Show kubeconfig for a context",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			stores, config, err := initialize()
+			if err != nil {
+				return fmt.Errorf("cannot initialize: %w", err)
+			}
+
+			kubeconfig, err := show.Show(args[0], stores, config, stateDirectory, noIndex)
+			if err != nil {
+				return fmt.Errorf("cannot show kubeconfig: %w", err)
+			}
+
+			cmd.Println(string(kubeconfig))
+			return nil
+		},
+		SilenceErrors: true,
+	}
+)
+
+func init() {
+	rootCommand.AddCommand(showCmd)
+}

--- a/pkg/subcommands/show/show.go
+++ b/pkg/subcommands/show/show.go
@@ -1,0 +1,51 @@
+// Copyright 2025 The Kubeswitch authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package show
+
+import (
+	"fmt"
+
+	"github.com/danielfoehrkn/kubeswitch/pkg"
+	storetypes "github.com/danielfoehrkn/kubeswitch/pkg/store/types"
+	"github.com/danielfoehrkn/kubeswitch/types"
+)
+
+func Show(desiredName string, stores []storetypes.KubeconfigStore, config *types.Config, stateDir string, noIndex bool) ([]byte, error) {
+	c, err := pkg.DoSearch(stores, config, stateDir, noIndex)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list contexts: %v", err)
+	}
+
+	for discoveredContext := range *c {
+		if discoveredContext.Error != nil {
+			continue
+		}
+
+		name := discoveredContext.Name
+		if discoveredContext.Alias != "" {
+			name = discoveredContext.Alias
+		}
+
+		if name == desiredName {
+			store := *discoveredContext.Store
+			kubeconfigData, err := store.GetKubeconfigForPath(discoveredContext.Path, discoveredContext.Tags)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get kubeconfig: %v", err)
+			}
+			return kubeconfigData, nil
+		}
+	}
+
+	return nil, fmt.Errorf("context not found")
+}


### PR DESCRIPTION
This pull request introduces a new `show` command to the Kubeswitch tool, which allows users to display the kubeconfig for a specified context. The changes include the creation of a new command file and the implementation of the corresponding functionality to retrieve and display the kubeconfig.

New command implementation:

* [`cmd/switcher/show.go`](diffhunk://#diff-4195d48d918a75f649b44cc13ab8d4d5896f695eeeab154730047e8dc18c1101R1-R48): Added a new `show` command that initializes the necessary components and displays the kubeconfig for the specified context.

Functionality to retrieve kubeconfig:

* [`pkg/subcommands/show/show.go`](diffhunk://#diff-4b3f7e7293a29916d53d63f4a23ec53bb79cf90b7524ec2ebf8fa372ed5e189dR1-R51): Implemented the `Show` function, which searches for the specified context and retrieves the corresponding kubeconfig data.