### PR TITLE
fix: Create plugin client with logger set to log level of PluginStore

### DIFF
--- a/pkg/store/kubeconfig_store_plugins.go
+++ b/pkg/store/kubeconfig_store_plugins.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -58,6 +59,11 @@ func (s *PluginStore) InitializePluginStore() error {
 		Cmd:             exec.Command(s.Config.CmdPath, s.Config.Args...),
 		AllowedProtocols: []plugin.Protocol{
 			plugin.ProtocolNetRPC, plugin.ProtocolGRPC},
+		Logger: hclog.New(&hclog.LoggerOptions{
+			Output: hclog.DefaultOutput,
+			Level:  hclog.Level(s.Logger.Logger.GetLevel()),
+			Name:   "plugin",
+		}),
 	})
 
 	// Connect via RPC

--- a/pkg/store/kubeconfig_store_plugins.go
+++ b/pkg/store/kubeconfig_store_plugins.go
@@ -50,6 +50,22 @@ func NewPluginStore(store types.KubeconfigStore) (*PluginStore, error) {
 	}, nil
 }
 
+func convertLogrusLevelToHclogLevel(level logrus.Level) hclog.Level {
+	switch level {
+	case logrus.TraceLevel:
+		return hclog.Trace
+	case logrus.DebugLevel:
+		return hclog.Debug
+	case logrus.InfoLevel:
+		return hclog.Info
+	case logrus.WarnLevel:
+		return hclog.Warn
+	default:
+		// Default to Error level for any other logrus levels (e.g. Fatal or Panic)
+		return hclog.Error
+	}
+}
+
 // InitializePluginStore initializes the plugin store
 func (s *PluginStore) InitializePluginStore() error {
 
@@ -61,7 +77,7 @@ func (s *PluginStore) InitializePluginStore() error {
 			plugin.ProtocolNetRPC, plugin.ProtocolGRPC},
 		Logger: hclog.New(&hclog.LoggerOptions{
 			Output: hclog.DefaultOutput,
-			Level:  hclog.LevelFromString(s.Logger.Logger.GetLevel().String()),
+			Level:  convertLogrusLevelToHclogLevel(s.Logger.Level),
 			Name:   "plugin",
 		}),
 	})

--- a/pkg/store/kubeconfig_store_plugins.go
+++ b/pkg/store/kubeconfig_store_plugins.go
@@ -61,7 +61,7 @@ func (s *PluginStore) InitializePluginStore() error {
 			plugin.ProtocolNetRPC, plugin.ProtocolGRPC},
 		Logger: hclog.New(&hclog.LoggerOptions{
 			Output: hclog.DefaultOutput,
-			Level:  hclog.Level(s.Logger.Logger.GetLevel()),
+			Level:  hclog.LevelFromString(s.Logger.Logger.GetLevel().String()),
 			Name:   "plugin",
 		}),
 	})


### PR DESCRIPTION
Fix for https://github.com/danielfoehrKn/kubeswitch/issues/181

When creating a plugin Client, create a Logger with the log level based on the log level of the PluginStore. Since these two resources use different log modules, add a function to convert the log level as closely as possible. 