### PR TITLE
chore: update workflows to use go.mod toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v6
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v6
       with:
-        go-version: '^1.21.0'
+        go-version-file: 'go.mod'
     - name: Run make check
       run: |
         export PATH=${PATH}:`go env GOPATH`/bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ jobs:
     environment: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
-          go-version: '^1.21.0'
+          go-version-file: 'go.mod'
       - name: Build the binary-files
         id: build_binary_files
         run: |


### PR DESCRIPTION
I noticed that PR #190 failed to build in CI because of some lints that have been introduced in go. This PR updates the github workflows to use the latest version of [actions/setup-go](https://github.com/actions/setup-go) which supports using a `go-version-file` (ie, [go.mod](https://github.com/danielfoehrKn/kubeswitch/blob/21becc509258bcd0e33fad690066d133a710cac4/go.mod#L5) which has a toolchain line). Running the workflow locally succeeded for me now.

Long-term it's probably a good idea to update the go version regularly. But this will unblock other PRs.